### PR TITLE
switched .recommendation and .similarity from GET to POST

### DIFF
--- a/lib/items.js
+++ b/lib/items.js
@@ -83,7 +83,7 @@ Items.prototype = {
     var endpoint = this._config.baseUrl + '/engines/itemsim/' + params.pio_engine + '/topn.json'
 
     request
-      .post(endpoint)
+      .get(endpoint)
       .query({
         pio_appkey: this._config.key
         , pio_iid: params.pio_iid
@@ -119,7 +119,7 @@ Items.prototype = {
     var endpoint = this._config.baseUrl + '/engines/itemrec/' + params.pio_engine + '/topn.json'
 
     request
-      .post(endpoint)
+      .get(endpoint)
       .query({
         pio_appkey: this._config.key
         , pio_uid: params.pio_uid


### PR DESCRIPTION
items.recommendation was returning an empty object. Switching from .post(endpoint) to .get(endpoint) on line 122 fixed this. Also fixed this for items.similarity. It was experiencing the same issue, however, I am not running a similarity engine, so I did not get a chance to test that fix. (It fails and I get a stack trace if I try)
